### PR TITLE
More abstract AbstractAggregator, *Aggregator are now using Abstract, tests and some ideas

### DIFF
--- a/src/main/java/org/calrissian/flowmix/api/aggregator/AbstractAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/AbstractAggregator.java
@@ -35,9 +35,8 @@ import org.calrissian.mango.domain.event.Event;
 /**
  *
  * Abstract aggregator for simple implementations
- * 
- * @author Miguel Antonio Fuentes Buchholtz
- * 
+ *
+ * @author Miguel A. Fuentes Buchholtz
  * @param <T> Aggregation result type
  */
 public abstract class AbstractAggregator<T> implements Aggregator {
@@ -117,13 +116,13 @@ public abstract class AbstractAggregator<T> implements Aggregator {
         }
         postAddition(item);
     }
-    
+
     /**
      *
      * @return aggregation result provided by implementation
      */
     protected abstract T aggregateResult();
-    
+
     /**
      *
      * @return

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/AbstractAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/AbstractAggregator.java
@@ -38,8 +38,9 @@ import org.calrissian.mango.domain.event.Event;
  *
  * @author Miguel A. Fuentes Buchholtz
  * @param <T> Aggregation result type
+ * @param <F> Field type
  */
-public abstract class AbstractAggregator<T> implements Aggregator {
+public abstract class AbstractAggregator<T, F> implements Aggregator {
 
     /**
      * field to operate with
@@ -98,9 +99,10 @@ public abstract class AbstractAggregator<T> implements Aggregator {
 
     /**
      *
-     * @param item item to work with after item is added to grouped values
+     * @param fieldValue field value to work with after item is added to grouped
+     * values
      */
-    public abstract void postAddition(WindowItem item);
+    public abstract void postAddition(F fieldValue);
 
     /**
      *
@@ -114,8 +116,23 @@ public abstract class AbstractAggregator<T> implements Aggregator {
                 groupedValues.put(group, item.getEvent().getAll(group));
             }
         }
-        postAddition(item);
+        if (item.getEvent().get(operatedField) != null) {
+            postAddition(((F) item.getEvent().get(operatedField).getValue()));
+        }
     }
+
+    /**
+     *
+     * @param item item to evict
+     */
+    @Override
+    public void evicted(WindowItem item) {
+        if (item.getEvent().get(operatedField) != null) {
+            evict((F) item.getEvent().get(operatedField).getValue());
+        }
+    }
+
+    public abstract void evict(F fieldValue);
 
     /**
      *

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/AbstractGrouplessAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/AbstractGrouplessAggregator.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2015 Calrissian.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.calrissian.flowmix.api.aggregator;
+
+import static java.lang.System.currentTimeMillis;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import static java.util.UUID.randomUUID;
+import org.apache.commons.lang.StringUtils;
+import org.calrissian.flowmix.api.Aggregator;
+import org.calrissian.flowmix.core.model.event.AggregatedEvent;
+import org.calrissian.flowmix.core.support.window.WindowItem;
+import org.calrissian.mango.domain.Tuple;
+import org.calrissian.mango.domain.event.BaseEvent;
+import org.calrissian.mango.domain.event.Event;
+
+/**
+ *
+ * This abstract Aggregator doesn't mantain the whole group, you need to add and
+ * evict the tuples with simple operations and emit them with complex ones.
+ *
+ * @author Miguel A. Fuentes Buchholtz
+ * @param <T> Aggregation result type
+ * @param <F> Field type
+ */
+public abstract class AbstractGrouplessAggregator<T, F> implements Aggregator {
+
+    /**
+     * field to operate with
+     */
+    public static final String OPERATED_FIELD = "operatedField";
+
+    /**
+     * output field
+     */
+    public static final String OUTPUT_FIELD = "outputField";
+
+    /**
+     * fields to group by
+     */
+    protected String[] groupByFields;
+
+    /**
+     * operated field name
+     */
+    protected String operatedField;
+
+    /**
+     * output field set by implementation
+     */
+    protected String outputField = getOutputField();
+
+    /**
+     *
+     * @return output field implementation
+     */
+    protected abstract String getOutputField();
+
+    /**
+     *
+     * @param configuration
+     */
+    @Override
+    public void configure(Map<String, String> configuration) {
+        if (configuration.get(GROUP_BY) != null) {
+            groupByFields = StringUtils.splitPreserveAllTokens(configuration.get(GROUP_BY), GROUP_BY_DELIM);
+        }
+        if (configuration.get(OUTPUT_FIELD) != null) {
+            outputField = configuration.get(OUTPUT_FIELD);
+        }
+        if (configuration.get(OPERATED_FIELD) != null) {
+            operatedField = configuration.get(OPERATED_FIELD);
+        } else {
+            throw new RuntimeException("Aggregator needs a field to operate it. Property missing: " + OPERATED_FIELD);
+        }
+    }
+
+    /**
+     *
+     * @param fieldValue field value to work with after item is added to grouped
+     * values
+     */
+    public abstract void postAddition(F fieldValue);
+
+    /**
+     *
+     * @param item
+     */
+    @Override
+    public void added(WindowItem item) {
+        if (item.getEvent().get(operatedField) != null) {
+            postAddition(((F) item.getEvent().get(operatedField).getValue()));
+        }
+    }
+
+    /**
+     *
+     * @param item item to evict
+     */
+    @Override
+    public void evicted(WindowItem item) {
+        if (item.getEvent().get(operatedField) != null) {
+            evict((F) item.getEvent().get(operatedField).getValue());
+        }
+    }
+
+    public abstract void evict(F fieldValue);
+
+    /**
+     *
+     * @return aggregation result provided by implementation
+     */
+    protected abstract T aggregateResult();
+
+    /**
+     *
+     * @return
+     */
+    @Override
+    public List<AggregatedEvent> aggregate() {
+        Event event = new BaseEvent(randomUUID().toString(), currentTimeMillis());
+        event.put(new Tuple(outputField, aggregateResult()));
+        return Collections.singletonList(new AggregatedEvent(event));
+    }
+
+}

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/AvgAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/AvgAggregator.java
@@ -15,10 +15,8 @@
  */
 package org.calrissian.flowmix.api.aggregator;
 
-import org.calrissian.flowmix.core.support.window.WindowItem;
-
 /**
- * TODO: test Simple average calculator, this calculates the average on when an
+ * Simple average calculator, this calculates the average on when an
  * aggregated Tuple is emitted, and just counts and sums on adding/evicting
  *
  * @author Miguel A. Fuentes Buchholtz
@@ -43,41 +41,21 @@ public class AvgAggregator extends AbstractAggregator<Double, Long> {
         return DEFAULT_OUTPUT_FIELD;
     }
 
-    /**
-     *
-     * @param fieldValue Window field value to operate with
-     */
     @Override
     public void postAddition(Long fieldValue) {
         this.sum += fieldValue;
         this.count++;
     }
 
-    /**
-     *
-     * @return freshly calculated average
-     */
-    @Override
-    protected Double aggregateResult() {
-        return ((double) this.sum) / ((double) this.count);
-    }
-
-    /**
-     *
-     * @param item item to evict
-     */
-    @Override
-    public void evicted(WindowItem item) {
-        if (item.getEvent().get(super.operatedField) != null) {
-            this.sum -= ((Long) item.getEvent().get(super.operatedField).getValue());
-            this.count--;
-        }
-    }
-
     @Override
     public void evict(Long fieldValue) {
         this.sum -= fieldValue;
         this.count--;
+    }
+    
+    @Override
+    protected Double aggregateResult() {
+        return ((double) this.sum) / ((double) this.count);
     }
 
 }

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/AvgAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/AvgAggregator.java
@@ -18,11 +18,11 @@ package org.calrissian.flowmix.api.aggregator;
 import org.calrissian.flowmix.core.support.window.WindowItem;
 
 /**
+ * TODO: test 
+ * Simple average calculator, this calculates the average on when an
+ * aggregated Tuple is emitted, and just counts and sums on adding/evicting
  *
- * Simple average calculator, this calculates the average on when an aggregated
- * Tuple is emitted, and just counts and sums on adding/evicting
- * 
- * @author Miguel Antonio Fuentes Buchholtz
+ * @author Miguel A. Fuentes Buchholtz
  */
 public class AvgAggregator extends AbstractAggregator<Double> {
 
@@ -36,6 +36,7 @@ public class AvgAggregator extends AbstractAggregator<Double> {
 
     /**
      * The output field for this implementation
+     *
      * @return output field name
      */
     @Override

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/AvgAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/AvgAggregator.java
@@ -18,13 +18,12 @@ package org.calrissian.flowmix.api.aggregator;
 import org.calrissian.flowmix.core.support.window.WindowItem;
 
 /**
- * TODO: test 
- * Simple average calculator, this calculates the average on when an
+ * TODO: test Simple average calculator, this calculates the average on when an
  * aggregated Tuple is emitted, and just counts and sums on adding/evicting
  *
  * @author Miguel A. Fuentes Buchholtz
  */
-public class AvgAggregator extends AbstractAggregator<Double> {
+public class AvgAggregator extends AbstractAggregator<Double, Long> {
 
     /**
      * Default output field name
@@ -46,14 +45,12 @@ public class AvgAggregator extends AbstractAggregator<Double> {
 
     /**
      *
-     * @param item Window item to operate with
+     * @param fieldValue Window field value to operate with
      */
     @Override
-    public void postAddition(WindowItem item) {
-        if (item.getEvent().get(super.operatedField) != null) {
-            this.sum += ((Long) item.getEvent().get(super.operatedField).getValue());
-            this.count++;
-        }
+    public void postAddition(Long fieldValue) {
+        this.sum += fieldValue;
+        this.count++;
     }
 
     /**
@@ -75,6 +72,12 @@ public class AvgAggregator extends AbstractAggregator<Double> {
             this.sum -= ((Long) item.getEvent().get(super.operatedField).getValue());
             this.count--;
         }
+    }
+
+    @Override
+    public void evict(Long fieldValue) {
+        this.sum -= fieldValue;
+        this.count--;
     }
 
 }

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/CountAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/CountAggregator.java
@@ -22,14 +22,14 @@ package org.calrissian.flowmix.api.aggregator;
  * @author The Calrissian Authors
  * @author Miguel A. Fuentes Buchholtz
  */
-public class CountAggregator extends AbstractAggregator<Long,Long> {
+public class CountAggregator extends AbstractAggregator<Long,Object> {
 
     public static final String DEFAULT_OUTPUT_FIELD = "count";
 
     protected long count = 0;
 
     @Override
-    public void evict(Long item) {
+    public void evict(Object item) {
         count--;
     }
 
@@ -39,7 +39,7 @@ public class CountAggregator extends AbstractAggregator<Long,Long> {
     }
 
     @Override
-    public void postAddition(Long item) {
+    public void postAddition(Object item) {
         count++;
     }
 

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/CountAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/CountAggregator.java
@@ -16,7 +16,6 @@
 package org.calrissian.flowmix.api.aggregator;
 
 /**
- * TODO: test 
  * Simple count calculator, this counts an aggregated tuple window
  * adds and subtracts accordingly (event added or evicted)
  *

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/CountAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/CountAggregator.java
@@ -15,8 +15,6 @@
  */
 package org.calrissian.flowmix.api.aggregator;
 
-import org.calrissian.flowmix.core.support.window.WindowItem;
-
 /**
  * TODO: test 
  * Simple count calculator, this counts an aggregated tuple window
@@ -25,14 +23,14 @@ import org.calrissian.flowmix.core.support.window.WindowItem;
  * @author The Calrissian Authors
  * @author Miguel A. Fuentes Buchholtz
  */
-public class CountAggregator extends AbstractAggregator<Long> {
+public class CountAggregator extends AbstractAggregator<Long,Long> {
 
     public static final String DEFAULT_OUTPUT_FIELD = "count";
 
     protected long count = 0;
 
     @Override
-    public void evicted(WindowItem item) {
+    public void evict(Long item) {
         count--;
     }
 
@@ -42,7 +40,7 @@ public class CountAggregator extends AbstractAggregator<Long> {
     }
 
     @Override
-    public void postAddition(WindowItem item) {
+    public void postAddition(Long item) {
         count++;
     }
 

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/FunctionAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/FunctionAggregator.java
@@ -15,6 +15,7 @@
  */
 package org.calrissian.flowmix.api.aggregator;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -61,8 +62,16 @@ public class FunctionAggregator<T, F> extends AbstractGrouplessAggregator<T, F> 
         //This is for keep the sums, counts and everything else needed
         private final Map<String, Object> aggregationData;
 
+        public AggregatorFunction() {
+            this.aggregationData = new HashMap<String,Object>();
+        }
+        
         public AggregatorFunction(Map<String, Object> aggregationData) {
             this.aggregationData = aggregationData;
+        }
+        
+        public Map<String, Object> getData(){
+            return this.aggregationData;
         }
 
         public abstract void add(FV value);

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/FunctionAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/FunctionAggregator.java
@@ -16,7 +16,6 @@
 package org.calrissian.flowmix.api.aggregator;
 
 import java.util.Map;
-import org.calrissian.flowmix.core.support.window.WindowItem;
 
 /**
  * All purpose function aggregator

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/FunctionAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/FunctionAggregator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 Calrissian.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.calrissian.flowmix.api.aggregator;
+
+import java.util.Map;
+import org.calrissian.flowmix.core.support.window.WindowItem;
+
+/**
+ * All purpose function aggregator
+ *
+ * @author Miguel A. Fuentes Buchholtz
+ * @param <T> result type
+ * @param <F> Field type
+ */
+public class FunctionAggregator<T, F> extends AbstractGrouplessAggregator<T, F> {
+
+    private final AggregatorFunction<T, F> function;
+
+    //This is optional, but I think it's simpler for someone trying to focus on the Function implementation
+    //by this class not being Abstract
+    public FunctionAggregator(String outputField, AggregatorFunction<T, F> function) {
+        super();
+        super.outputField = outputField;
+        this.function = function;
+    }
+
+    @Override
+    protected String getOutputField() {
+        return null;
+    }
+
+    @Override
+    protected T aggregateResult() {
+        return this.function.aggregate();
+    }
+
+    @Override
+    public void postAddition(F fieldValue) {
+        this.function.add(fieldValue);
+    }
+
+    @Override
+    public void evict(F fieldValue) {
+        this.function.evict(fieldValue);
+    }
+
+    public static abstract class AggregatorFunction<FT, FV> {
+
+        //This is for keep the sums, counts and everything else needed
+        private final Map<String, Object> aggregationData;
+
+        public AggregatorFunction(Map<String, Object> aggregationData) {
+            this.aggregationData = aggregationData;
+        }
+
+        public abstract void add(FV value);
+
+        public abstract void evict(FV value);
+
+        public abstract FT aggregate();
+
+    }
+
+}

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/JavascriptFunctionAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/JavascriptFunctionAggregator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015 Calrissian.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.calrissian.flowmix.api.aggregator;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.script.Invocable;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+
+/**
+ *
+ * @author Miguel A. Fuentes Buchholtz
+ * @param <T> Aggregation result type
+ * @param <F> Field type
+ */
+public class JavascriptFunctionAggregator<T,F> extends AbstractGrouplessAggregator<T,F> {
+
+    private final ScriptEngineManager manager = new ScriptEngineManager();
+    private final ScriptEngine engine = manager.getEngineByName("js");
+    private final Invocable invocable;
+    
+    //This is optional, but I think it's simpler for someone trying to focus on the Function implementation
+    //by this class not being Abstract
+    /*
+    * @param javascript has to have an implementation of postAddition(F fieldValue), evict(F fieldValue) and T aggregateResult()
+    */
+    public JavascriptFunctionAggregator(String outputField, String javascript) throws ScriptException {
+        super();
+        super.outputField = outputField;
+        engine.eval(javascript);
+        this.invocable = (Invocable) engine;
+    }
+
+    @Override
+    protected String getOutputField() {
+        return null;
+    }
+
+    @Override
+    public void postAddition(F fieldValue) {
+        try {
+            this.invocable.invokeFunction("postAddition", fieldValue );
+        } catch (ScriptException ex) {
+            Logger.getLogger(JavascriptFunctionAggregator.class.getName()).log(Level.SEVERE, null, ex);
+        } catch (NoSuchMethodException ex) {
+            Logger.getLogger(JavascriptFunctionAggregator.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+
+    @Override
+    public void evict(F fieldValue) {
+        try {
+            this.invocable.invokeFunction("fieldValue", fieldValue);
+        } catch (ScriptException ex) {
+            Logger.getLogger(JavascriptFunctionAggregator.class.getName()).log(Level.SEVERE, null, ex);
+        } catch (NoSuchMethodException ex) {
+            Logger.getLogger(JavascriptFunctionAggregator.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+
+    @Override
+    protected T aggregateResult() {
+        try {
+            return (T) this.invocable.invokeFunction("aggregateResult", (new Object[0]));
+        } catch (ScriptException ex) {
+            Logger.getLogger(JavascriptFunctionAggregator.class.getName()).log(Level.SEVERE, null, ex);
+        } catch (NoSuchMethodException ex) {
+            Logger.getLogger(JavascriptFunctionAggregator.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        return null;
+    }
+    
+}

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/LongSumAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/LongSumAggregator.java
@@ -32,6 +32,7 @@ import org.calrissian.mango.domain.event.Event;
 import static java.lang.System.currentTimeMillis;
 import static java.util.UUID.randomUUID;
 
+@Deprecated
 public class LongSumAggregator implements Aggregator {
 
   public static final String SUM_FIELD = "sumField";

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/SumAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/SumAggregator.java
@@ -15,25 +15,27 @@
  */
 package org.calrissian.flowmix.api.aggregator;
 
-import org.calrissian.flowmix.core.support.window.WindowItem;
-
 /**
  * TODO: test 
- * Simple count calculator, this counts an aggregated tuple window
+ * Simple sum calculator, this sums an aggregated tuple window
  * adds and subtracts accordingly (event added or evicted)
  *
  * @author The Calrissian Authors
  * @author Miguel A. Fuentes Buchholtz
  */
-public class CountAggregator extends AbstractAggregator<Long> {
+import org.calrissian.flowmix.core.support.window.WindowItem;
 
-    public static final String DEFAULT_OUTPUT_FIELD = "count";
+public class SumAggregator extends AbstractAggregator<Long> {
 
-    protected long count = 0;
+    public static final String DEFAULT_OUTPUT_FIELD = "sum";
+
+    protected long sum = 0;
 
     @Override
     public void evicted(WindowItem item) {
-        count--;
+        if (item.getEvent().get(super.operatedField) != null) {
+            sum -= ((Long) item.getEvent().get(super.operatedField).getValue());
+        }
     }
 
     @Override
@@ -43,11 +45,13 @@ public class CountAggregator extends AbstractAggregator<Long> {
 
     @Override
     public void postAddition(WindowItem item) {
-        count++;
+        if (item.getEvent().get(super.operatedField) != null) {
+            sum += ((Long) item.getEvent().get(super.operatedField).getValue());
+        }
     }
 
     @Override
     protected Long aggregateResult() {
-        return count;
+        return sum;
     }
 }

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/SumAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/SumAggregator.java
@@ -16,7 +16,7 @@
 package org.calrissian.flowmix.api.aggregator;
 
 /**
- * TODO: test Simple sum calculator, this sums an aggregated tuple window adds
+ * Simple sum calculator, this sums an aggregated tuple window adds
  * and subtracts accordingly (event added or evicted)
  *
  * @author The Calrissian Authors

--- a/src/main/java/org/calrissian/flowmix/api/aggregator/SumAggregator.java
+++ b/src/main/java/org/calrissian/flowmix/api/aggregator/SumAggregator.java
@@ -16,26 +16,21 @@
 package org.calrissian.flowmix.api.aggregator;
 
 /**
- * TODO: test 
- * Simple sum calculator, this sums an aggregated tuple window
- * adds and subtracts accordingly (event added or evicted)
+ * TODO: test Simple sum calculator, this sums an aggregated tuple window adds
+ * and subtracts accordingly (event added or evicted)
  *
  * @author The Calrissian Authors
  * @author Miguel A. Fuentes Buchholtz
  */
-import org.calrissian.flowmix.core.support.window.WindowItem;
-
-public class SumAggregator extends AbstractAggregator<Long> {
+public class SumAggregator extends AbstractAggregator<Long, Long> {
 
     public static final String DEFAULT_OUTPUT_FIELD = "sum";
 
     protected long sum = 0;
 
     @Override
-    public void evicted(WindowItem item) {
-        if (item.getEvent().get(super.operatedField) != null) {
-            sum -= ((Long) item.getEvent().get(super.operatedField).getValue());
-        }
+    public void evict(Long value) {
+        sum -= value;
     }
 
     @Override
@@ -44,10 +39,8 @@ public class SumAggregator extends AbstractAggregator<Long> {
     }
 
     @Override
-    public void postAddition(WindowItem item) {
-        if (item.getEvent().get(super.operatedField) != null) {
-            sum += ((Long) item.getEvent().get(super.operatedField).getValue());
-        }
+    public void postAddition(Long value) {
+        sum += value;
     }
 
     @Override

--- a/src/test/java/org/calrissian/flowmix/api/aggregator/AvgAggregatorTest.java
+++ b/src/test/java/org/calrissian/flowmix/api/aggregator/AvgAggregatorTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 Calrissian.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.calrissian.flowmix.api.aggregator;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * @author Miguel A. Fuentes Buchholtz
+ */
+public class AvgAggregatorTest {
+
+    public AvgAggregatorTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void test() {
+        System.out.println("AvgAggregatorTest");
+        AvgAggregator instance = new AvgAggregator();
+        instance.postAddition((long) 1);
+        instance.postAddition((long) 10);
+        instance.postAddition((long) -5);
+        instance.evict((long) 1);
+        Double result = instance.aggregateResult();
+        Double expectedResult = 2.5;
+        assertEquals(expectedResult, result);
+    }
+
+}

--- a/src/test/java/org/calrissian/flowmix/api/aggregator/CountAggregatorTest.java
+++ b/src/test/java/org/calrissian/flowmix/api/aggregator/CountAggregatorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 Calrissian.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.calrissian.flowmix.api.aggregator;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * @author Miguel A. Fuentes Buchholtz
+ */
+public class CountAggregatorTest {
+    
+    public CountAggregatorTest() {
+    }
+    
+    @BeforeClass
+    public static void setUpClass() {
+    }
+    
+    @AfterClass
+    public static void tearDownClass() {
+    }
+    
+    @Before
+    public void setUp() {
+    }
+    
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void test() {
+        System.out.println("CountAggregatorTest");
+        CountAggregator instance = new CountAggregator();
+        instance.postAddition((long)33);
+        instance.postAddition((long)33);
+        instance.postAddition((long)33);
+        instance.postAddition((long)33);
+        instance.evict((long)1);
+        Long result = instance.aggregateResult();
+        Long expectedResult = (long)3;
+        assertEquals(expectedResult, result);
+    }
+
+}

--- a/src/test/java/org/calrissian/flowmix/api/aggregator/FunctionAggregatorTest.java
+++ b/src/test/java/org/calrissian/flowmix/api/aggregator/FunctionAggregatorTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2015 Calrissian.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.calrissian.flowmix.api.aggregator;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author miguel
+ */
+public class FunctionAggregatorTest {
+
+    public FunctionAggregatorTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void test() {
+        //Wanted to use standard deviation for testing this Aggregator, is a very heavy operation
+        System.out.println("FunctionAggregatorTest");
+        FunctionAggregator<Double, Long> instance = new FunctionAggregator<Double, Long>("stnd", new FunctionAggregator.AggregatorFunction<Double, Long>() {
+
+            private static final String VALUES = "values";
+            private static final String MEAN = "mean";
+
+            private Double calculateAverage(List<Long> marks) {
+                Long sum = (long) 0;
+                if (!marks.isEmpty()) {
+                    for (Long mark : marks) {
+                        sum += mark;
+                    }
+                    return sum.doubleValue() / marks.size();
+                }
+                return (double) sum;
+            }
+
+            @Override
+            public void add(Long value) {
+                if (value == null || !getData().containsKey(VALUES)) {
+                    getData().put(VALUES, new ArrayList<Long>());
+                }
+                ((ArrayList<Long>) getData().get(VALUES)).add(value);
+                getData().put(MEAN, calculateAverage((ArrayList<Long>) getData().get(VALUES)));
+            }
+
+            @Override
+            public void evict(Long value) {
+                if (value == null || !getData().containsKey(VALUES) || ((ArrayList<Long>) getData().get(VALUES)).isEmpty()) {
+                    return;
+                }
+                ((ArrayList<Long>) getData().get(VALUES)).remove(value);
+                getData().put(MEAN, calculateAverage((ArrayList<Long>) getData().get(VALUES)));
+            }
+
+            @Override
+            public Double aggregate() {
+                Long[] sq = new Long[((ArrayList<Long>) getData().get(VALUES)).size()];
+                ((ArrayList<Long>) getData().get(VALUES)).toArray(sq);
+                Double sum = 0.0;
+                for (Long e : sq) {
+                    Double e2 = (e - (Double) getData().get(MEAN));
+                    sum = sum + (e2 * e2);
+                }
+                return Math.sqrt((sum / sq.length));
+            }
+        });
+        instance.postAddition((long) 1);
+        instance.postAddition((long) 1);
+        instance.postAddition((long) 20);
+        instance.postAddition((long) 5);
+        instance.postAddition((long) -3);
+        instance.evict((long) 1);
+        Double result = instance.aggregateResult();
+        Double expResult = 8.699856320652657;
+        assertEquals(expResult, result);
+    }
+
+}

--- a/src/test/java/org/calrissian/flowmix/api/aggregator/JavascriptFunctionAggregatorTest.java
+++ b/src/test/java/org/calrissian/flowmix/api/aggregator/JavascriptFunctionAggregatorTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2015 Calrissian.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.calrissian.flowmix.api.aggregator;
+
+import javax.script.ScriptException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author miguel
+ */
+public class JavascriptFunctionAggregatorTest {
+    
+    public JavascriptFunctionAggregatorTest() {
+    }
+    
+    @BeforeClass
+    public static void setUpClass() {
+    }
+    
+    @AfterClass
+    public static void tearDownClass() {
+    }
+    
+    @Before
+    public void setUp() {
+    }
+    
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void testGetOutputField() throws ScriptException {
+        System.out.println("JavascriptFunctionAggregatorTest");
+        String js = "var sum = 0;"
+                + "postAddition = function(fieldValue){ sum = sum + fieldValue; };"
+                + "evict = function(fieldValue){ sum = sum - fieldValue; };"
+                + "aggregateResult = function(){ return sum; }";
+        JavascriptFunctionAggregator<Double,Long> instance = new JavascriptFunctionAggregator<Double,Long>("stnd", js);
+        instance.postAddition((long) 1);
+        instance.postAddition((long) 1);
+        instance.postAddition((long) 1);
+        instance.postAddition((long) 3);
+        instance.evict((long)3);
+        instance.postAddition((long) 1);
+        Double result = instance.aggregateResult();
+        long expectedResult = (long)7;
+        assertEquals(expectedResult, result.longValue());
+    }
+
+}

--- a/src/test/java/org/calrissian/flowmix/api/aggregator/SumAggregatorTest.java
+++ b/src/test/java/org/calrissian/flowmix/api/aggregator/SumAggregatorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 Calrissian.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.calrissian.flowmix.api.aggregator;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * @author Miguel A. Fuentes Buchholtz
+ */
+public class SumAggregatorTest {
+    
+    public SumAggregatorTest() {
+    }
+    
+    @BeforeClass
+    public static void setUpClass() {
+    }
+    
+    @AfterClass
+    public static void tearDownClass() {
+    }
+    
+    @Before
+    public void setUp() {
+    }
+    
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void test() {
+        System.out.println("SumAggregatorTest");
+        SumAggregator instance = new SumAggregator();
+        instance.postAddition((long) 1);
+        instance.postAddition((long) 1);
+        instance.postAddition((long) 1);
+        instance.postAddition((long) 3);
+        instance.evict((long)3);
+        instance.postAddition((long) 1);
+        Long result = instance.aggregateResult();
+        Long expectedResult = (long)4;
+        assertEquals(expectedResult, result);
+    }
+
+}


### PR DESCRIPTION
Hi!

I changed the Abstract Aggregator to a more abstract one, maybe is something to discuss so please check it, every Aggregator is adapted to the Abstract one, test where done, and some extra optional things:
- AbstractGrouplessAggregator: without the group burden, I'm going to JMeter this to compare
- FunctionAggregator: maybe useless, but you could have a set of functions and use at will with this
- JavascriptFunctionAggregator: I saw some CEP implementations where they use javascript for functions, maybe this is not the best approach nor the place to do it but it was fun anyways

Deprecated LongSumAggregator, why the Long prefix? because of the Type?

Best regards!